### PR TITLE
공공데이터 API 호출 및 DB 저장

### DIFF
--- a/app/src/main/java/com/example/corona_center/App.kt
+++ b/app/src/main/java/com/example/corona_center/App.kt
@@ -1,7 +1,9 @@
 package com.example.corona_center
 
 import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
 
+@HiltAndroidApp
 class App : Application() {
 
 }

--- a/buildSrc/src/main/kotlin/Dependency.kt
+++ b/buildSrc/src/main/kotlin/Dependency.kt
@@ -26,6 +26,7 @@ object Versions {
     const val RX_JAVA_ADAPTER = "2.5.0"
     const val KOIN = "3.2.0"
     const val GLIDE = "4.12.0"
+    const val HILT = "2.38.1"
 
     const val JUNIT = "4.13.2"
     const val ANDROID_JUNIT = "1.1.3"
@@ -77,6 +78,8 @@ object Libraries {
     const val KOIN                       = "io.insert-koin:koin-core:${Versions.KOIN}"
     const val KOIN_ANDROID               = "io.insert-koin:koin-android:${Versions.KOIN}"
     const val GLIDE                      = "com.github.bumptech.glide:glide:${Versions.GLIDE}"
+    const val HILT                       = "com.google.dagger:hilt-android:${Versions.HILT}"
+    const val HILT_COMPILER              = "com.google.dagger:hilt-compiler:${Versions.HILT}"
 }
 
 object UnitTest {

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -4,6 +4,9 @@ plugins {
     id 'kotlin-kapt'
 }
 
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
+
 android {
     compileSdk 32
 
@@ -13,6 +16,8 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
+
+        buildConfigField "String", "DECODING_KEY", properties['decoding_key']
     }
 
     buildTypes {

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -62,4 +62,8 @@ dependencies {
     implementation AndroidX.ROOM_RUNTIME
     implementation AndroidX.ROOM_KTX
     kapt AndroidX.ROOM_COMPILER
+
+    // Hilt
+    implementation Libraries.HILT
+    kapt Libraries.HILT_COMPILER
 }

--- a/data/src/main/java/com/example/data/api/CenterApi.kt
+++ b/data/src/main/java/com/example/data/api/CenterApi.kt
@@ -1,0 +1,17 @@
+package com.example.data.api
+
+import com.example.data.BuildConfig
+import com.example.data.model.CenterEntity
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.Query
+
+interface CenterApi {
+    // Github에 Key값이 올라가지 않도록 숨김. Key를 Header에 넣어 API 요청
+    @Headers("Authorization: ${BuildConfig.DECODING_KEY}")
+    @GET("15077586/v1/centers")
+    suspend fun getCenterList(
+        @Query("page") page: Int,
+        @Query("perPage") perPage: Int = 10
+    ): CenterEntity
+}

--- a/data/src/main/java/com/example/data/db/CenterDao.kt
+++ b/data/src/main/java/com/example/data/db/CenterDao.kt
@@ -1,0 +1,20 @@
+package com.example.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.example.domain.model.Center
+import com.example.domain.util.Constants.TABLE_NAME
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CenterDao {
+    @Query("SELECT * FROM $TABLE_NAME")
+    fun readCenterList(): Flow<List<Center>>
+
+    @Insert
+    suspend fun writeCenter(centerList: List<Center>)
+
+    @Query("DELETE FROM $TABLE_NAME")
+    suspend fun deleteAllCenters()
+}

--- a/data/src/main/java/com/example/data/db/CenterDatabase.kt
+++ b/data/src/main/java/com/example/data/db/CenterDatabase.kt
@@ -1,0 +1,10 @@
+package com.example.data.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.example.domain.model.Center
+
+@Database(entities = [Center::class], version = 1)
+abstract class CenterDatabase: RoomDatabase() {
+    abstract fun centerDao(): CenterDao
+}

--- a/data/src/main/java/com/example/data/db/CenterTypeConverters.kt
+++ b/data/src/main/java/com/example/data/db/CenterTypeConverters.kt
@@ -1,0 +1,14 @@
+package com.example.data.db
+
+import androidx.room.TypeConverter
+import com.example.domain.model.Center
+import com.google.gson.Gson
+
+// 리스트를 한 번에 Room에 저장하기 위해 Converter 사용
+class CenterTypeConverters {
+    @TypeConverter
+    fun CenterToJson(value: List<Center>): String = Gson().toJson(value)
+
+    @TypeConverter
+    fun JsonToCenter(value: String) = Gson().fromJson(value, Array<Center>::class.java).toList()
+}

--- a/data/src/main/java/com/example/data/di/LocalDataModule.kt
+++ b/data/src/main/java/com/example/data/di/LocalDataModule.kt
@@ -1,0 +1,41 @@
+package com.example.data.di
+
+import android.content.Context
+import androidx.room.Room
+import com.example.data.db.CenterDao
+import com.example.data.db.CenterDatabase
+import com.example.data.repository.center.local.CenterLocalDataSource
+import com.example.data.repository.center.local.CenterLocalDataSourceImpl
+import com.example.domain.util.Constants.DB_NAME
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+class LocalDataModule {
+    @Provides
+    @Singleton
+    fun provideCenterDatabase(@ApplicationContext context: Context): CenterDatabase {
+        return Room.databaseBuilder(
+            context,
+            CenterDatabase::class.java,
+            DB_NAME
+        ).fallbackToDestructiveMigration().build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideCenterDao(centerDatabase: CenterDatabase): CenterDao {
+        return centerDatabase.centerDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideCenterLocalDataSource(centerDao: CenterDao): CenterLocalDataSource {
+        return CenterLocalDataSourceImpl(centerDao)
+    }
+}

--- a/data/src/main/java/com/example/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/example/data/di/NetworkModule.kt
@@ -1,0 +1,65 @@
+package com.example.data.di
+
+import com.example.data.BuildConfig
+import com.example.data.api.CenterApi
+import com.example.domain.util.Constants.CENTER_BASE_URL
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class NetworkModule {
+    @Provides
+    @Singleton
+    fun provideHttpClient(): OkHttpClient {
+        val client = OkHttpClient.Builder()
+            .readTimeout(10, TimeUnit.SECONDS)
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .writeTimeout(10, TimeUnit.SECONDS)
+
+        if(BuildConfig.DEBUG) {
+            client.addInterceptor(getLoggingInterceptor())
+        }
+
+        return client.build()
+    }
+
+    @Singleton
+    @Provides
+    fun provideCenterRetrofit(
+        okHttpClient: OkHttpClient
+    ): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(CENTER_BASE_URL)
+            .client(okHttpClient)
+            .client(provideHttpClient())
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideConverterFactory(): GsonConverterFactory {
+        return GsonConverterFactory.create()
+    }
+
+    @Provides
+    @Singleton
+    fun provideCenterApiService(retrofit: Retrofit): CenterApi {
+        return retrofit.create(CenterApi::class.java)
+    }
+
+    private fun getLoggingInterceptor() =
+        HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.HEADERS
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+}

--- a/data/src/main/java/com/example/data/di/RemoteDataModule.kt
+++ b/data/src/main/java/com/example/data/di/RemoteDataModule.kt
@@ -1,0 +1,20 @@
+package com.example.data.di
+
+import com.example.data.api.CenterApi
+import com.example.data.repository.center.remote.CenterRemoteDataSource
+import com.example.data.repository.center.remote.CenterRemoteDataSourceImpl
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+class RemoteDataModule {
+    @Provides
+    @Singleton
+    fun provideCenterRemoteDataSource(centerApi: CenterApi): CenterRemoteDataSource {
+        return CenterRemoteDataSourceImpl(centerApi)
+    }
+}

--- a/data/src/main/java/com/example/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/example/data/di/RepositoryModule.kt
@@ -1,0 +1,24 @@
+package com.example.data.di
+
+import com.example.data.repository.CenterRepositoryImpl
+import com.example.data.repository.center.local.CenterLocalDataSource
+import com.example.data.repository.center.remote.CenterRemoteDataSource
+import com.example.domain.repository.CenterRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+class RepositoryModule {
+    @Provides
+    @Singleton
+    fun provideCenterRepository(
+        centerRemoteDataSource: CenterRemoteDataSource,
+        centerLocalDataSource: CenterLocalDataSource
+    ): CenterRepository {
+        return CenterRepositoryImpl(centerRemoteDataSource, centerLocalDataSource)
+    }
+}

--- a/data/src/main/java/com/example/data/mapper/CenterMapper.kt
+++ b/data/src/main/java/com/example/data/mapper/CenterMapper.kt
@@ -1,0 +1,21 @@
+package com.example.data.mapper
+
+import com.example.data.model.CenterEntity
+import com.example.domain.model.Center
+
+object CenterMapper {
+    operator fun invoke(centerEntity: CenterEntity): List<Center> {
+        return centerEntity.data.toList().map {
+            Center(
+                id = it.id,
+                address = it.address,
+                centerName = it.centerName,
+                facilityName = it.facilityName,
+                phoneNumber = it.phoneNumber,
+                updatedAt = it.updatedAt,
+                lat = it.lat,
+                lng = it.lng
+            )
+        }
+    }
+}

--- a/data/src/main/java/com/example/data/model/CenterEntity.kt
+++ b/data/src/main/java/com/example/data/model/CenterEntity.kt
@@ -1,0 +1,5 @@
+package com.example.data.model
+
+data class CenterEntity (
+    val data: List<DataEntity>
+)

--- a/data/src/main/java/com/example/data/model/DataEntity.kt
+++ b/data/src/main/java/com/example/data/model/DataEntity.kt
@@ -1,0 +1,13 @@
+package com.example.data.model
+
+data class DataEntity (
+    val id: Int,
+    val address: String,
+    val centerName: String,
+    val facilityName: String,
+    val phoneNumber: String,
+    val updatedAt: String,
+    val centerType: String,
+    val lat: String,
+    val lng: String
+)

--- a/data/src/main/java/com/example/data/repository/CenterRepositoryImpl.kt
+++ b/data/src/main/java/com/example/data/repository/CenterRepositoryImpl.kt
@@ -1,0 +1,55 @@
+package com.example.data.repository
+
+import com.example.data.mapper.CenterMapper
+import com.example.data.repository.center.local.CenterLocalDataSource
+import com.example.data.repository.center.remote.CenterRemoteDataSource
+import com.example.domain.model.Center
+import com.example.domain.repository.CenterRepository
+import com.example.domain.util.Result
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class CenterRepositoryImpl @Inject constructor(
+    private val centerRemoteDataSource: CenterRemoteDataSource,
+    private val centerLocalDataSource: CenterLocalDataSource
+) : CenterRepository {
+
+    override suspend fun getCenterList(page: Int): Flow<List<Center>> {
+        return flow {
+            centerRemoteDataSource.getCenterList(page).collect {
+                emit(CenterMapper(it))
+            }
+        }
+    }
+
+    override fun readCenterList(): Flow<List<Center>> {
+        return centerLocalDataSource.readCenterList()
+    }
+
+    override suspend fun writeCenter(center: List<Center>): Result<Any> {
+        return try {
+            withContext(CoroutineScope(Dispatchers.IO).coroutineContext) {
+                centerLocalDataSource.writeCenter(center)
+            }
+            Result.success(null)
+        } catch (error: Exception) {
+            Result.error(error.message.toString(), null)
+        }
+    }
+
+    override suspend fun deleteAllCenters(): Result<Any> {
+        return try {
+            withContext(CoroutineScope(Dispatchers.IO).coroutineContext) {
+                centerLocalDataSource.deleteAllCenters()
+            }
+            Result.success(null)
+        } catch (error: Exception) {
+            Result.error(error.message.toString(), null)
+        }
+    }
+}

--- a/data/src/main/java/com/example/data/repository/center/local/CenterLocalDataSource.kt
+++ b/data/src/main/java/com/example/data/repository/center/local/CenterLocalDataSource.kt
@@ -1,0 +1,10 @@
+package com.example.data.repository.center.local
+
+import com.example.domain.model.Center
+import kotlinx.coroutines.flow.Flow
+
+interface CenterLocalDataSource {
+    fun readCenterList(): Flow<List<Center>>
+    suspend fun writeCenter(centerList: List<Center>)
+    suspend fun deleteAllCenters()
+}

--- a/data/src/main/java/com/example/data/repository/center/local/CenterLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/example/data/repository/center/local/CenterLocalDataSourceImpl.kt
@@ -1,0 +1,22 @@
+package com.example.data.repository.center.local
+
+import com.example.data.db.CenterDao
+import com.example.domain.model.Center
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class CenterLocalDataSourceImpl @Inject constructor(
+    private val dao: CenterDao
+): CenterLocalDataSource {
+    override fun readCenterList(): Flow<List<Center>> {
+        return dao.readCenterList()
+    }
+
+    override suspend fun writeCenter(centerList: List<Center>) {
+        return dao.writeCenter(centerList)
+    }
+
+    override suspend fun deleteAllCenters() {
+        return dao.deleteAllCenters()
+    }
+}

--- a/data/src/main/java/com/example/data/repository/center/remote/CenterRemoteDataSource.kt
+++ b/data/src/main/java/com/example/data/repository/center/remote/CenterRemoteDataSource.kt
@@ -1,0 +1,8 @@
+package com.example.data.repository.center.remote
+
+import com.example.data.model.CenterEntity
+import kotlinx.coroutines.flow.Flow
+
+interface CenterRemoteDataSource {
+    suspend fun getCenterList(page: Int): Flow<CenterEntity>
+}

--- a/data/src/main/java/com/example/data/repository/center/remote/CenterRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/example/data/repository/center/remote/CenterRemoteDataSourceImpl.kt
@@ -1,0 +1,18 @@
+package com.example.data.repository.center.remote
+
+import com.example.data.api.CenterApi
+import com.example.data.model.CenterEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class CenterRemoteDataSourceImpl @Inject constructor(
+    private val centerApi: CenterApi
+) : CenterRemoteDataSource {
+
+    override suspend fun getCenterList(page: Int): Flow<CenterEntity> {
+        return flow {
+            emit(centerApi.getCenterList(page))
+        }
+    }
+}

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -55,4 +55,8 @@ dependencies {
     implementation AndroidX.ROOM_RUNTIME
     implementation AndroidX.ROOM_KTX
     kapt AndroidX.ROOM_COMPILER
+
+    // Hilt
+    implementation Libraries.HILT
+    kapt Libraries.HILT_COMPILER
 }

--- a/domain/src/main/java/com/example/domain/model/Center.kt
+++ b/domain/src/main/java/com/example/domain/model/Center.kt
@@ -1,0 +1,18 @@
+package com.example.domain.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.example.domain.util.Constants
+
+@Entity(tableName = Constants.TABLE_NAME)
+data class Center(
+    @PrimaryKey
+    val id: Int,
+    val address: String,
+    val centerName: String,
+    val facilityName: String,
+    val phoneNumber: String,
+    val updatedAt: String,
+    val lat: String,
+    val lng: String
+)

--- a/domain/src/main/java/com/example/domain/repository/CenterRepository.kt
+++ b/domain/src/main/java/com/example/domain/repository/CenterRepository.kt
@@ -1,0 +1,12 @@
+package com.example.domain.repository
+
+import com.example.domain.model.Center
+import com.example.domain.util.Result
+import kotlinx.coroutines.flow.Flow
+
+interface CenterRepository {
+    suspend fun getCenterList(page: Int): Flow<List<Center>>
+    fun readCenterList(): Flow<List<Center>>
+    suspend fun writeCenter(center: List<Center>): Result<Any>
+    suspend fun deleteAllCenters(): Result<Any>
+}

--- a/domain/src/main/java/com/example/domain/usecase/DeleteAllCentersUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/DeleteAllCentersUseCase.kt
@@ -1,0 +1,11 @@
+package com.example.domain.usecase
+
+import com.example.domain.repository.CenterRepository
+import com.example.domain.util.Result
+import javax.inject.Inject
+
+class DeleteAllCentersUseCase @Inject constructor(
+    private val centerRepository: CenterRepository
+) {
+    suspend operator fun invoke(): Result<Any> = centerRepository.deleteAllCenters()
+}

--- a/domain/src/main/java/com/example/domain/usecase/GetCenterListUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/GetCenterListUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.domain.usecase
+
+import com.example.domain.model.Center
+import com.example.domain.repository.CenterRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+
+class GetCenterListUseCase @Inject constructor(
+    private val centerRepository: CenterRepository
+) {
+    suspend operator fun invoke(page: Int): Flow<List<Center>> = centerRepository.getCenterList(page)
+}

--- a/domain/src/main/java/com/example/domain/usecase/ReadCenterListUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/ReadCenterListUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.domain.usecase
+
+import com.example.domain.model.Center
+import com.example.domain.repository.CenterRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class ReadCenterListUseCase @Inject constructor(
+    private val centerRepository: CenterRepository
+) {
+    operator fun invoke(): Flow<List<Center>> = centerRepository.readCenterList()
+}

--- a/domain/src/main/java/com/example/domain/usecase/WriteCenterListUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/WriteCenterListUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.domain.usecase
+
+import com.example.domain.model.Center
+import com.example.domain.repository.CenterRepository
+import com.example.domain.util.Result
+import javax.inject.Inject
+
+class WriteCenterListUseCase @Inject constructor(
+    private val centerRepository: CenterRepository
+) {
+    suspend operator fun invoke(center: List<Center>): Result<Any> = centerRepository.writeCenter(center)
+}

--- a/domain/src/main/java/com/example/domain/util/Constants.kt
+++ b/domain/src/main/java/com/example/domain/util/Constants.kt
@@ -1,0 +1,8 @@
+package com.example.domain.util
+
+object Constants {
+    const val CENTER_BASE_URL = "https://api.odcloud.kr/api/"
+
+    const val DB_NAME = "corona_center"
+    const val TABLE_NAME = "center"
+}

--- a/domain/src/main/java/com/example/domain/util/Result.kt
+++ b/domain/src/main/java/com/example/domain/util/Result.kt
@@ -1,0 +1,21 @@
+package com.example.domain.util
+
+data class Result<out T>(
+    val status: Status,
+    var data: @UnsafeVariance T?,
+    val message:String?
+){
+    companion object{
+        fun <T> success(data: T?): Result<T> {
+            return Result(Status.SUCCESS, data, null)
+        }
+
+        fun <T> error(msg: String, data: T?): Result<T> {
+            return Result(Status.ERROR, data, msg)
+        }
+
+        fun <T> fail(): Result<T> {
+            return Result(Status.FAIL, null, null)
+        }
+    }
+}

--- a/domain/src/main/java/com/example/domain/util/Status.kt
+++ b/domain/src/main/java/com/example/domain/util/Status.kt
@@ -1,0 +1,7 @@
+package com.example.domain.util
+
+enum class Status {
+    SUCCESS,
+    FAIL,
+    ERROR
+}

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
+    id 'dagger.hilt.android.plugin'
 }
 
 android {
@@ -71,4 +72,15 @@ dependencies {
 
     // SplashScreen
     implementation AndroidX.SPLASH_SCREEN
+
+    // Hilt
+    implementation Libraries.HILT
+    kapt Libraries.HILT_COMPILER
+
+    // viewModel
+    implementation AndroidX.LIFECYCLE_VIEWMODEL_KTX
+
+    // ktx
+    implementation AndroidX.ACTIVITY_KTX
+    implementation AndroidX.FRAGMENT_KTX
 }

--- a/presentation/src/main/java/com/example/presentation/views/MainActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/views/MainActivity.kt
@@ -1,15 +1,47 @@
 package com.example.presentation.views
 
-import android.app.Activity
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import androidx.core.splashscreen.SplashScreen
-import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import android.util.Log
+import androidx.activity.viewModels
+import com.example.domain.util.Status
 import com.example.presentation.R
+import com.example.presentation.config.BaseActivity
+import com.example.presentation.databinding.ActivityMainBinding
+import dagger.hilt.android.AndroidEntryPoint
 
-class MainActivity : AppCompatActivity() {
+@AndroidEntryPoint
+class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
+    private val viewModel: MainViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+
+        initEvent()
+    }
+
+    private fun initEvent() {
+        with(viewModel) {
+            centerList.observe(this@MainActivity) {
+                Log.d(TAG, "Center List: $it")
+            }
+
+            problem.observe(this@MainActivity) {
+                when(it.status) {
+                    Status.FAIL -> {
+                        Log.d(TAG, "FAIL : ${it.message}")
+                    }
+                    Status.ERROR -> {
+                        Log.d(TAG, "ERROR : ${it.message}")
+                    }
+                    Status.SUCCESS -> {
+                        Log.d(TAG, "SUCCESS")
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "MainActivity_Corona"
     }
 }

--- a/presentation/src/main/java/com/example/presentation/views/MainViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/views/MainViewModel.kt
@@ -1,0 +1,99 @@
+package com.example.presentation.views
+
+import androidx.lifecycle.*
+import com.example.domain.model.Center
+import com.example.domain.usecase.DeleteAllCentersUseCase
+import com.example.domain.usecase.GetCenterListUseCase
+import com.example.domain.usecase.ReadCenterListUseCase
+import com.example.domain.usecase.WriteCenterListUseCase
+import com.example.domain.util.Result
+import com.example.domain.util.Status
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    private val getCenterListUseCase: GetCenterListUseCase,
+    private val readCenterListUseCase: ReadCenterListUseCase,
+    private val writeCenterListUseCase: WriteCenterListUseCase,
+    private val deleteAllCentersUseCase: DeleteAllCentersUseCase
+): ViewModel() {
+    private val _problem = MutableLiveData<Result<Any>>()
+    val problem: LiveData<Result<Any>> get() = _problem
+
+    private val _centerList = MutableLiveData<List<Center>>()
+    val centerList: LiveData<List<Center>> get() = _centerList
+
+    // 이 값을 통해 10개의 페이지의 저장 진행률을 나타냄
+    // ex) 3 -> 30%, 10 -> 100%
+    private val _progressCount = MutableLiveData(0)
+
+    // 가장 먼저 저장된 db를 삭제하고 작업 시작
+    init {
+        deleteAllCenters()
+    }
+
+    private fun getCenterList() {
+        for(page in 1..10) {
+            viewModelScope.launch {
+                getCenterListUseCase(page)
+                    .onStart { showProgress() }
+                    .onCompletion { hideProgress() }
+                    .catch { _problem.postValue(Result.fail()) }
+                    .collect {
+                        if(it.isEmpty()) {
+                            _problem.postValue(Result.error("Response is empty", it))
+                        } else {
+                            _centerList.postValue(it)
+                            _problem.postValue(Result.success(it))
+                            writeCenterList(it)
+                        }
+                    }
+            }
+        }
+    }
+
+    private fun readCenterList(): LiveData<List<Center>> {
+        return readCenterListUseCase().asLiveData()
+    }
+
+    private fun writeCenterList(centerList: List<Center>) {
+        viewModelScope.launch {
+            val result = writeCenterListUseCase(centerList)
+            if(result.status == Status.ERROR) {
+                _problem.postValue(result)
+            } else {
+                // 저장을 성공적으로 완료하면 진행률을 나타내는 값을 +1 한다.
+                _progressCount.value = _progressCount.value?.plus(1)
+            }
+        }
+    }
+
+    private fun deleteAllCenters() {
+        viewModelScope.launch {
+            val result = deleteAllCentersUseCase()
+            if(result.status == Status.ERROR) {
+                _problem.postValue(result)
+            } else {
+                getCenterList()
+            }
+        }
+    }
+
+    private fun showProgress() {
+
+    }
+
+    private fun hideProgress() {
+
+    }
+
+    companion object {
+        private const val TAG = "MainViewModel_Corona"
+    }
+}

--- a/presentation/src/main/res/layout/activity_main.xml
+++ b/presentation/src/main/res/layout/activity_main.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".views.MainActivity">
+    xmlns:tools="http://schemas.android.com/tools">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".views.MainActivity">
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
## 개요
- Resolves #1 
- 공공데이터 API 호출
- 받아온 데이터를 내부 DB에 저장

## 작업사항
- 멀티 모듈 적용
- `Clean Architecture` 적용
- `Hilt`를 이용해 의존성 주입
- `Room`을 이용해 DB에 데이터 저장
    - 리스트 저장을 위해 TypeConverter 사용
- Key 값 노출을 막기 위해 BuildConfig 사용